### PR TITLE
Feat/global alert and popup component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import '../styles/globals.css';
+import Popup from '@/components/common/Popup';
 import Providers from './providers';
 
 export const metadata = {
@@ -10,6 +11,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => (
   <html lang="en">
     <body>
       <Providers>{children}</Providers>
+      <Popup />
     </body>
   </html>
 );

--- a/src/components/common/Popup.tsx
+++ b/src/components/common/Popup.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import useBoundStore from '@/store';
+import type { AlertType } from '@/store/alertSlice';
+import { twMerge } from 'tailwind-merge';
+
+type ToastProps = {
+  type?: AlertType;
+  message: string;
+};
+
+const variants: { [key in AlertType]: string } = {
+  default: 'border-primary bg-primarySubtle',
+  error: 'border-red-700 bg-red-200',
+  success: 'border-green-700 bg-green-200',
+};
+
+const Toast: React.FC<ToastProps> = ({ type = 'default', message }) => (
+  <div
+    className={twMerge(
+      'flex items-center px-3 py-2 rounded-lg border-2',
+      variants[type],
+    )}
+  >
+    <p>{message}</p>
+  </div>
+);
+
+type PopupProps = {
+  /**
+   * Variant of the component
+   */
+  variant?: 'toast' | 'banner';
+};
+
+const Popup: React.FC<PopupProps> = ({ variant = 'toast' }) => {
+  const alert = useBoundStore((state) => state.alert);
+
+  if (!alert.message) {
+    return null;
+  }
+
+  let displayEl = null;
+
+  if (variant === 'toast') {
+    displayEl = <Toast type={alert.type} message={alert.message} />;
+  }
+
+  return (
+    <div className="fixed z-50 left-3 bottom-6" role="alert">
+      {displayEl}
+    </div>
+  );
+};
+
+export default Popup;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,2 +1,3 @@
 export const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL;
 export const LOCAL_STORAGE_SAVE_MS = 1000;
+export const ALERT_AUTO_DISMISS = 5000;

--- a/src/store/alertSlice.ts
+++ b/src/store/alertSlice.ts
@@ -1,0 +1,35 @@
+import type { StateCreator } from 'zustand';
+
+import { ALERT_AUTO_DISMISS } from '@/config/constants';
+
+export type AlertType = 'default' | 'error' | 'success';
+
+export type Alert = {
+  type?: AlertType;
+  message?: string;
+};
+
+export type AlertSlice = {
+  alert: Alert;
+  setAlert: (alert: Alert) => void;
+  resetAlert: () => void;
+};
+
+const initialState = {
+  type: undefined,
+  message: undefined,
+};
+
+export const createAlertSlice: StateCreator<AlertSlice, [], [], AlertSlice> = (
+  set,
+  get,
+) => ({
+  alert: initialState,
+  setAlert: (newAlert) => {
+    set(() => ({ alert: newAlert }));
+    setTimeout(() => {
+      get().resetAlert();
+    }, ALERT_AUTO_DISMISS);
+  },
+  resetAlert: () => set(() => ({ alert: initialState })),
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,9 @@
+import { create } from 'zustand';
+
+import { type AlertSlice, createAlertSlice } from './alertSlice';
+
+const useBoundStore = create<AlertSlice>((...a) => ({
+  ...createAlertSlice(...a),
+}));
+
+export default useBoundStore;


### PR DESCRIPTION
I've added a global alert store that is used alongside the `Popup` component to display any **toasts** or **banners** to the user in a form of a popup (i.e. like a visual notification)